### PR TITLE
Blender3.0にて、多角形面にナイフツールを使用すると、失敗する問題を修正しました。

### DIFF
--- a/Addons/PolyQuilt/QMesh/QSnap.py
+++ b/Addons/PolyQuilt/QMesh/QSnap.py
@@ -34,7 +34,7 @@ class QSnap :
         cls.ref = cls.ref + 1
 
     @classmethod
-    def remove_ref( cls ) :            
+    def remove_ref( cls ) :
         cls.ref = cls.ref - 1
         if cls.ref == 0 :
             if cls.instance :
@@ -69,7 +69,7 @@ class QSnap :
 
     @staticmethod
     def snap_objects( context ) :
-        active_obj = context.active_object        
+        active_obj = context.active_object
         objects = context.visible_objects
 #           objects = context.selected_objects
         objects_array = [obj for obj in objects if obj != active_obj and obj.type == 'MESH']
@@ -133,7 +133,7 @@ class QSnap :
     @classmethod
     def adjust_verts( cls , obj , verts , is_fix_to_x_zero ) :
         if cls.instance != None and cls.instance.bvh_list :
-            dist = bpy.context.scene.tool_settings.double_threshold                        
+            dist = bpy.context.scene.tool_settings.double_threshold
             find_nearest =  cls.instance.__find_nearest
             matrix = obj.matrix_world
             for vert in verts :
@@ -202,7 +202,7 @@ class QSnap :
         if (location_r - ray.origin).length <= (location_i - ray.origin).length :
             return location_r , normal_r , obj_r
         else :
-            return location_i , normal_i , obj_i        
+            return location_i , normal_i , obj_i
 
     def __raycast_double( self , ray : pqutil.Ray ) :
         # ターゲットからビュー方向にレイを飛ばす
@@ -218,7 +218,7 @@ class QSnap :
             if (location_r - ray.origin).length <= (location_i - ray.origin).length :
                 return location_r , normal_r , face_r
             else :
-                return location_i , normal_i , face_i        
+                return location_i , normal_i , face_i
         return None , None , None
 
     def __find_nearest( self, pos : mathutils.Vector ) :

--- a/Addons/PolyQuilt/__init__.py
+++ b/Addons/PolyQuilt/__init__.py
@@ -14,8 +14,8 @@
 bl_info = {
     "name" : "PolyQuilt",
     "author" : "Sakana3",
-    "version": (1, 3, 1),
-    "blender" : (2, 83, 0),
+    "version": (1, 3, 11),
+    "blender" : (3, 3, 0),
     "location": "View3D > Mesh > PolyQuilt",
     "description": "Lowpoly Tool",
     "warning" : "",
@@ -31,7 +31,7 @@ from .pq_icon import *
 from .pq_tool import PolyQuiltTools
 from .pq_tool_ui import VIEW3D_PT_tools_polyquilt_options
 from .pq_keymap_editor import PQ_OT_DirtyKeymap
-from .gizmo_preselect import * 
+from .gizmo_preselect import *
 from .pq_preferences import *
 from .translation import pq_translation_dict
 
@@ -49,7 +49,7 @@ classes = (
 
 
 def register():
-    bpy.app.translations.register(__name__, pq_translation_dict)    
+    bpy.app.translations.register(__name__, pq_translation_dict)
     register_icons()
     register_updater(bl_info)
 
@@ -69,7 +69,7 @@ def unregister():
         bpy.utils.unregister_tool(tool['tool'])
 
     for cls in reversed(classes):
-        bpy.utils.unregister_class(cls)        
+        bpy.utils.unregister_class(cls)
 
     bpy.utils.unregister_class(pq_operator_add_empty_object.OBJECT_OT_add_object)
     bpy.utils.unregister_manual_map(pq_operator_add_empty_object.add_object_manual_map)

--- a/Addons/PolyQuilt/pq_preferences.py
+++ b/Addons/PolyQuilt/pq_preferences.py
@@ -408,19 +408,11 @@ class PQ_OT_SetupUnityLikeKeymap(bpy.types.Operator) :
 
     def execute(self, context):
         for keymap in context.window_manager.keyconfigs.user.keymaps:
-#            print( keymap.name + "----" + keymap.space_type )
-            if keymap.space_type == 'EMPTY' or keymap.space_type == 'NODE_EDITOR'  or keymap.space_type == 'IMAGE_EDITOR' :
-                # Add View2D RMB pan
-                if keymap.name == 'Image' :
-                    PQ_OT_SetupUnityLikeKeymap.AddKeyToKeyMap( keymap , 'image.view_pan', 'MOUSE' , 'RIGHTMOUSE' , 'CLICK_DRAG' )
-                if keymap.name == "View2D" :
-                    PQ_OT_SetupUnityLikeKeymap.AddKeyToKeyMap( keymap , 'view2d.pan', 'MOUSE' , 'RIGHTMOUSE' , 'CLICK_DRAG' )
-
+            if keymap.space_type == 'EMPTY':
                 for key in keymap.keymap_items:
                     if True not in [ key.any , key.alt , key.ctrl ,key.shift ]:
-                        if key.map_type == 'MOUSE' and key.type == 'RIGHTMOUSE' and key.value != 'CLICK_DRAG' :
+                        if key.map_type == 'MOUSE' and key.type == 'RIGHTMOUSE' :
                             key.value = 'CLICK'
-
         for keymap in context.window_manager.keyconfigs.user.keymaps:
             if keymap.space_type == 'VIEW_3D':
                 for key in keymap.keymap_items:
@@ -440,12 +432,3 @@ class PQ_OT_SetupUnityLikeKeymap(bpy.types.Operator) :
                         key.shift = False
 
         return {'FINISHED'}
-
-    def AddKeyToKeyMap( keymap , idname ,map_type, type , value , any=False, shift=0, ctrl=0, alt=0, oskey=0, key_modifier='NONE', repeat=False, head=False) :
-        for key in keymap.keymap_items:
-            if key.idname == idname and key.map_type == map_type and key.type ==type and key.value == value and key.any == any and key.alt == alt and key.ctrl == ctrl and key.shift == shift :
-                key.active = True
-                break
-        else :
-            keymap.keymap_items.new(idname = idname, type = type , value = value , any=any, shift=shift, ctrl=ctrl, alt=alt, oskey=oskey, key_modifier=key_modifier, repeat=repeat, head=head)
-

--- a/Addons/PolyQuilt/subtools/maintool_brush.py
+++ b/Addons/PolyQuilt/subtools/maintool_brush.py
@@ -45,7 +45,7 @@ class MainToolBrush(MainTool) :
     name = "Brush"
 
     def __init__(self,op,currentTarget, button) :
-        super().__init__(op,currentTarget, button)        
+        super().__init__(op,currentTarget, button)
         brush_tbl = {
             'SMOOTH' : SubToolBrushRelax ,
             'MOVE' : SubToolBrushMove ,
@@ -55,7 +55,7 @@ class MainToolBrush(MainTool) :
         brush = op.brush_type
         brush_type = brush_tbl[ brush ]
 
-        self.callback = { 
+        self.callback = {
             MBEventType.Release         : [] ,
             MBEventType.Click           : [SubToolAutoQuad] ,
             MBEventType.LongClick       : [] ,
@@ -81,7 +81,7 @@ class MainToolBrush(MainTool) :
 
         def Draw() :
             radius = gizmo.preferences.brush_size * dpm()
-            strength = gizmo.preferences.brush_strength  
+            strength = gizmo.preferences.brush_strength
             if drawAutoQuad :
                 drawAutoQuad()
             with draw_util.push_pop_projection2D() :
@@ -95,9 +95,9 @@ class MainToolBrush(MainTool) :
 
     def OnDraw( self , context  ) :
         radius = self.preferences.brush_size * dpm()
-        strength = self.preferences.brush_strength          
+        strength = self.preferences.brush_strength
         draw_util.draw_circle2D( self.mouse_pos , radius * strength , color = (1,0.25,0.25,0.25), fill = False , subdivide = 64 , dpi= False )
-        draw_util.draw_circle2D( self.mouse_pos , radius , color = (1,1,1,0.5), fill = False , subdivide = 64 , dpi= False )        
+        draw_util.draw_circle2D( self.mouse_pos , radius , color = (1,1,1,0.5), fill = False , subdivide = 64 , dpi= False )
 
         self.LMBEvent.Draw( self.mouse_pos )
 
@@ -106,7 +106,7 @@ class MainToolBrush(MainTool) :
             draw_util.DrawFont( "Radius = " + '{:.0f}'.format(self.preferences.brush_size * dpm() ) , 10 , self.mouse_pos , (0,-8) )
 
     def OnDraw3D( self , context  ) :
-        if not self.LMBEvent.presureComplite :        
+        if not self.LMBEvent.presureComplite :
             if SubToolAutoQuad.Check( self , self.currentTarget ) :
                 draw = SubToolAutoQuad.DrawHighlight(self,self.currentTarget)
                 if draw :
@@ -131,7 +131,7 @@ class MainToolBrush(MainTool) :
     def change_brush_size( cls , preferences , context , brush_size_value , brush_strong_value ):
         if context.area.type == 'VIEW_3D' :
             a = (preferences.brush_size * preferences.brush_size) / 40000.0 + 0.1
-            preferences.brush_size = preferences.brush_size + brush_size_value * a       
+            preferences.brush_size = preferences.brush_size + brush_size_value * a
             strength = min( max( 0 , preferences.brush_strength + brush_strong_value ) , 1 )
             preferences.brush_strength = strength
             context.area.tag_redraw()
@@ -140,8 +140,8 @@ class MainToolBrushDelete(MainToolBrush) :
     name = "BrushDeleteSubTool"
 
     def __init__(self,op,currentTarget, button) :
-        super().__init__(op,currentTarget, button)        
-        self.callback = { 
+        super().__init__(op,currentTarget, button)
+        self.callback = {
             MBEventType.Release         : [] ,
             MBEventType.Click           : [] ,
             MBEventType.LongClick       : [] ,
@@ -160,8 +160,8 @@ class MainToolBrushRelax(MainToolBrush) :
     name = "BrushRelaxSubTool"
 
     def __init__(self,op,currentTarget, button) :
-        super().__init__(op,currentTarget, button)        
-        self.callback = { 
+        super().__init__(op,currentTarget, button)
+        self.callback = {
             MBEventType.Release         : [] ,
             MBEventType.Click           : [] ,
             MBEventType.LongClick       : [] ,
@@ -180,8 +180,8 @@ class MainToolBrushMove(MainToolBrush) :
     name = "BrushMoveSubTool"
 
     def __init__(self,op,currentTarget, button) :
-        super().__init__(op,currentTarget, button)        
-        self.callback = { 
+        super().__init__(op,currentTarget, button)
+        self.callback = {
             MBEventType.Release         : [] ,
             MBEventType.Click           : [] ,
             MBEventType.LongClick       : [] ,

--- a/Addons/PolyQuilt/subtools/subtool_brush_delete.py
+++ b/Addons/PolyQuilt/subtools/subtool_brush_delete.py
@@ -33,7 +33,7 @@ class SubToolBrushDelete(SubToolEx) :
         self.radius = self.preferences.brush_size * dpm()
         self.strength = self.preferences.brush_strength
         self.mirror_tbl = {}
-        matrix = self.bmo.obj.matrix_world        
+        matrix = self.bmo.obj.matrix_world
         self.remove_faces = self.collect_faces( bpy.context , self.startMousePos )
         if self.bmo.is_mirror_mode :
             mirror = { self.bmo.find_mirror( f ) for f in self.remove_faces }
@@ -48,7 +48,7 @@ class SubToolBrushDelete(SubToolEx) :
     def DrawHighlight( cls , gizmo , element ) :
         def Draw() :
             radius = gizmo.preferences.brush_size * dpm()
-            strength = gizmo.preferences.brush_strength  
+            strength = gizmo.preferences.brush_strength
             color = gizmo.preferences.delete_color
             with draw_util.push_pop_projection2D() :
                 draw_util.draw_circle2D( gizmo.mouse_pos , radius * strength , color = color, fill = False , subdivide = 64 , dpi= False )
@@ -77,14 +77,14 @@ class SubToolBrushDelete(SubToolEx) :
         return 'RUNNING_MODAL'
 
     def OnDraw( self , context  ) :
-        color = self.preferences.delete_color 
+        color = self.preferences.delete_color
         draw_util.draw_circle2D( self.mouse_pos , self.radius , color , fill = False , subdivide = 64 , dpi= False , width = 1.0 )
 
     def OnDraw3D( self , context  ) :
         alpha = self.preferences.highlight_face_alpha
-        vertex_size = self.preferences.highlight_vertex_size        
-        width = self.preferences.highlight_line_width        
-        color = self.preferences.delete_color 
+        vertex_size = self.preferences.highlight_vertex_size
+        width = self.preferences.highlight_line_width
+        color = self.preferences.delete_color
         draw_util.drawElementsHilight3D( self.bmo.obj , self.remove_faces , vertex_size , width , alpha , color )
 
     def collect_faces( self , context , coord ) :
@@ -94,7 +94,10 @@ class SubToolBrushDelete(SubToolEx) :
         select_stack = SelectStack( context , bm )
         select_stack.push()
         select_stack.select_mode(False,False,True)
-        bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
+        if bpy.app.version >= (3,0,0):
+            bpy.ops.view3d.select_circle( x = int(coord.x) , y = int(coord.y) , radius = int(radius) , wait_for_input=False, mode='SET' )
+        else:
+            bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
         faces = { f for f in self.bmo.bm.faces if f.select }
         select_stack.pop()
         return faces

--- a/Addons/PolyQuilt/subtools/subtool_brush_move.py
+++ b/Addons/PolyQuilt/subtools/subtool_brush_move.py
@@ -33,7 +33,7 @@ class SubToolBrushMove(SubToolEx) :
         self.radius = self.preferences.brush_size * dpm()
         self.strength = self.preferences.brush_strength
         self.mirror_tbl = {}
-        matrix = self.bmo.obj.matrix_world        
+        matrix = self.bmo.obj.matrix_world
         self.verts = self.CollectVerts( bpy.context , self.startMousePos )
 
         if self.bmo.is_mirror_mode :
@@ -48,7 +48,7 @@ class SubToolBrushMove(SubToolEx) :
     def OnUpdate( self , context , event ) :
         if event.type == 'MOUSEMOVE':
             self.UpdateVerts(context)
-        elif event.type == self.rootTool.buttonType : 
+        elif event.type == self.rootTool.buttonType :
             if event.value == 'RELEASE' :
                 if self.verts :
                     self.bmo.UpdateMesh()
@@ -63,7 +63,7 @@ class SubToolBrushMove(SubToolEx) :
     def DrawHighlight( cls , gizmo , element ) :
         def Draw() :
             radius = gizmo.preferences.brush_size * dpm()
-            strength = gizmo.preferences.brush_strength  
+            strength = gizmo.preferences.brush_strength
             with draw_util.push_pop_projection2D() :
                 draw_util.draw_circle2D( gizmo.mouse_pos , radius * strength , color = (1,0.25,0.25,0.25), fill = False , subdivide = 64 , dpi= False )
                 draw_util.draw_circle2D( gizmo.mouse_pos , radius , color = (1,1,1,0.5), fill = False , subdivide = 64 , dpi= False )
@@ -71,7 +71,7 @@ class SubToolBrushMove(SubToolEx) :
 
     def OnDraw( self , context  ) :
         radius = self.preferences.brush_size * dpm()
-        strength = self.preferences.brush_strength  
+        strength = self.preferences.brush_strength
 
         draw_util.draw_circle2D( self.mouse_pos , radius * strength , color = (1,0.25,0.25,0.25), fill = False , subdivide = 64 , dpi= False )
         draw_util.draw_circle2D( self.startMousePos , self.radius , color = (0.75,0.75,1,1), fill = False , subdivide = 64 , dpi= False , width = 1.0 )
@@ -94,7 +94,10 @@ class SubToolBrushMove(SubToolEx) :
 
         select_stack.push()
         select_stack.select_mode(True,False,False)
-        bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
+        if bpy.app.version >= (3,0,0):
+            bpy.ops.view3d.select_circle( x = int(coord.x) , y = int(coord.y) , radius = int(radius) , wait_for_input=False, mode='SET' )
+        else:
+            bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
 #        bm.select_flush(False)
 
         is_target = QSnap.is_target
@@ -126,12 +129,12 @@ class SubToolBrushMove(SubToolEx) :
         return { v : x for v,x in coords.items() if x }
 
     def UpdateVerts( self , context ) :
-        is_fix_zero = self.preferences.fix_to_x_zero or self.bmo.is_mirror_mode        
+        is_fix_zero = self.preferences.fix_to_x_zero or self.bmo.is_mirror_mode
         region = context.region
         rv3d = context.region_data
         move = self.mouse_pos - self.startMousePos
-        matrix = self.bmo.obj.matrix_world         
-        matrix_inv = self.bmo.obj.matrix_world.inverted()         
+        matrix = self.bmo.obj.matrix_world
+        matrix_inv = self.bmo.obj.matrix_world.inverted()
         region_2d_to_location_3d = pqutil.region_2d_to_location_3d
         is_x_zero_pos = self.bmo.is_x_zero_pos
         zero_pos = self.bmo.zero_pos
@@ -144,7 +147,7 @@ class SubToolBrushMove(SubToolEx) :
             x = QSnap.adjust_point( x )
             x = matrix_inv @ x
             if is_fix_zero and is_x_zero_pos(orig) :
-                x.x = 0 
+                x.x = 0
             v.co = x
 
         if self.bmo.is_mirror_mode :
@@ -160,7 +163,7 @@ class SubToolBrushMove(SubToolEx) :
                     else :
                         mirror.co = mirror_pos(vert.co)
 
-        self.bmo.UpdateMesh()        
+        self.bmo.UpdateMesh()
 
     @classmethod
     def GetCursor(cls) :

--- a/Addons/PolyQuilt/subtools/subtool_brush_relax.py
+++ b/Addons/PolyQuilt/subtools/subtool_brush_relax.py
@@ -47,7 +47,7 @@ class SubToolBrushRelax(SubToolEx) :
     def DrawHighlight( cls , gizmo , element ) :
         def Draw() :
             radius = gizmo.preferences.brush_size * dpm()
-            strength = gizmo.preferences.brush_strength  
+            strength = gizmo.preferences.brush_strength
             with draw_util.push_pop_projection2D() :
                 draw_util.draw_circle2D( gizmo.mouse_pos , radius * strength , color = (1,0.25,0.25,0.25), fill = False , subdivide = 64 , dpi= False )
                 draw_util.draw_circle2D( gizmo.mouse_pos , radius , color = (1,1,1,0.5), fill = False , subdivide = 64 , dpi= False )
@@ -56,7 +56,7 @@ class SubToolBrushRelax(SubToolEx) :
     def OnUpdate( self , context , event ) :
         if event.type == 'MOUSEMOVE':
             self.DoRelax( context ,self.mouse_pos )
-        elif event.type == self.rootTool.buttonType : 
+        elif event.type == self.rootTool.buttonType :
             if event.value == 'RELEASE' :
                 if self.dirty  :
                     self.bmo.UpdateMesh()
@@ -90,7 +90,10 @@ class SubToolBrushRelax(SubToolEx) :
 
         select_stack.push()
         select_stack.select_mode(True,False,False)
-        bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
+        if bpy.app.version >= (3,0,0):
+            bpy.ops.view3d.select_circle( x = int(coord.x) , y = int(coord.y) , radius = int(radius) , wait_for_input=False, mode='SET' )
+        else:
+            bpy.ops.view3d.select_circle( x = coord.x , y = coord.y , radius = radius , wait_for_input=False, mode='SET' )
 #        bm.select_flush(False)
 
         occlusion_tbl_get = self.occlusion_tbl.get
@@ -122,7 +125,7 @@ class SubToolBrushRelax(SubToolEx) :
 
         select_stack.pop()
 
-        return { c[0]: [c[1],c[2]] for c in coords if c != None } 
+        return { c[0]: [c[1],c[2]] for c in coords if c != None }
 
     def MirrorVert( self , context , coords ) :
         # ミラー頂点を検出

--- a/Addons/PolyQuilt/subtools/subtool_fin_slice.py
+++ b/Addons/PolyQuilt/subtools/subtool_fin_slice.py
@@ -37,12 +37,12 @@ class SubToolFinSlice(SubTool) :
     def OnForcus( self , context , event  ) :
         if event.type == 'MOUSEMOVE':
             self.slice_rate , self.slice_dist = self.CalcRate(context,self.mouse_pos)
-        return self.slice_rate > 0 
+        return self.slice_rate > 0
 
     def OnUpdate( self , context , event ) :
         if event.type == 'RIGHTMOUSE' :
             return 'FINISHED'
-        elif event.type == 'LEFTMOUSE' : 
+        elif event.type == 'LEFTMOUSE' :
             if event.value == 'RELEASE' :
                 if self.slice_rate == 1 :
                     self.DoSplit()
@@ -125,7 +125,7 @@ class SubToolFinSlice(SubTool) :
         _edges = []
 
         def append( vert , other_vert ) :
-            for edge in vert.link_edges :        
+            for edge in vert.link_edges :
                 if other_vert is not None :
                     if edge not in other_vert.link_edges :
                         _edges.append( edge )
@@ -154,7 +154,7 @@ class SubToolFinSlice(SubTool) :
              use_grid_fill=False,
              use_only_quads = False ,
              seed = 0 ,
-             use_sphere = False 
+             use_sphere = False
         )
 
         for e in ret['geom_inner'] :
@@ -163,4 +163,3 @@ class SubToolFinSlice(SubTool) :
             QSnap.adjust_verts( self.bmo.obj , [ v for v in ret['geom_inner'] if isinstance( v , bmesh.types.BMVert ) ] , self.preferences.fix_to_x_zero )
 
         self.bmo.UpdateMesh()
-

--- a/Addons/PolyQuilt/subtools/subtool_knife.py
+++ b/Addons/PolyQuilt/subtools/subtool_knife.py
@@ -40,24 +40,24 @@ class SubToolKnife(SubTool) :
         self.goalElement = ElementItem.Empty()
 
     def OnUpdate( self , context , event ) :
-        self.goalElement = self.bmo.PickElement( self.mouse_pos , self.preferences.distance_to_highlight, elements = ['EDGE','VERT'] )   
+        self.goalElement = self.bmo.PickElement( self.mouse_pos , self.preferences.distance_to_highlight, elements = ['EDGE','VERT'] )
         if self.goalElement.isNotEmpty and not self.goalElement.isFace :
             self.goalElement.set_snap_div( self.preferences.loopcut_division )
             self.endPos = self.goalElement.coord
         else :
             self.endPos = self.mouse_pos
-        
+
         if event.type == 'MOUSEMOVE':
             if( self.startPos - self.endPos ).length > 2 :
                 self.CalcKnife( context,self.startPos,self.endPos )
         elif event.type == 'RIGHTMOUSE' :
             if event.value == 'RELEASE' :
                 return 'FINISHED'
-        elif event.type == 'LEFTMOUSE' : 
+        elif event.type == 'LEFTMOUSE' :
             if event.value == 'RELEASE' :
                 if self.cut_edges or self.cut_edges_mirror  :
                     self.DoKnife(context,self.startPos,self.endPos)
-                    self.bmo.UpdateMesh()                
+                    self.bmo.UpdateMesh()
                     return 'FINISHED'
                 return 'CANCELLED'
         return 'RUNNING_MODAL'
@@ -104,8 +104,8 @@ class SubToolKnife(SubTool) :
         plane0_distance_point = plane0.distance_point
         plane1_distance_point = plane1.distance_point
         epsilon = sys.float_info.epsilon
-        
-        def chk( edge ) :        
+
+        def chk( edge ) :
             p0 = edge.verts[0].co
             p1 = edge.verts[1].co
             p = slice_plane_intersect_line( p0 , p1 )
@@ -151,7 +151,7 @@ class SubToolKnife(SubTool) :
             self.bmo.UpdateMesh()
             cut_edges_mirror = self.calc_slice( slice_plane , plane0 , plane1 )
             if cut_edges_mirror :
-                faces = [ face for face in self.bmo.faces if face.hide is False ]          
+                faces = [ face for face in self.bmo.faces if face.hide is False ]
                 elements = list(cut_edges_mirror.keys()) + faces[:]
                 ret = bmesh.ops.bisect_plane(bm,geom=elements,dist=threshold,plane_co= slice_plane.origin ,plane_no= slice_plane.vector ,use_snap_center=False,clear_outer=False,clear_inner=False)
                 for e in ret['geom_cut'] :

--- a/Addons/PolyQuilt/utils/pqutil.py
+++ b/Addons/PolyQuilt/utils/pqutil.py
@@ -41,7 +41,7 @@ class Plane :
         return Plane( origin , vector )
 
     def from_screen_slice( context , startPos , endPos ) :
-        rv3d = context.region_data   
+        rv3d = context.region_data
         region = context.region
 #       pc = region_2d_to_origin_3d(region, rv3d, startPos)
         no = region_2d_to_vector_3d(region, rv3d, startPos)
@@ -112,7 +112,7 @@ class Ray :
 
     @staticmethod
     def from_screen( context , coord : mathutils.Vector) :
-        rv3d = context.region_data   
+        rv3d = context.region_data
         region = context.region
         origin = region_2d_to_origin_3d(region, rv3d, coord)
         vector = region_2d_to_vector_3d(region, rv3d, coord)
@@ -171,7 +171,7 @@ class Ray :
         elif d1 >= dt :
             return 0.0
 
-        return max( 0 , min( 1 , d0 / dt ))        
+        return max( 0 , min( 1 , d0 / dt ))
 
     def hit_to_line_pos( self , v0 , v1 ) :
         h0 , h1 , d = self.distance( Ray( v0 , (v1-v0) ) )
@@ -186,7 +186,7 @@ class Ray :
             val =  0.0
         else :
             val = d0 / dt
-        
+
         return v0 + (v1-v0) * val
 
 
@@ -353,7 +353,7 @@ def location_3d_to_region_2d( coord ) :
     prj = perspective_matrix @ Vector((coord[0], coord[1], coord[2], 1.0))
     if prj.w > 0.0:
         width_half = region.width / 2.0
-        height_half = region.height / 2.0 
+        height_half = region.height / 2.0
 
         return Vector((width_half + width_half * (prj.x / prj.w),
                        height_half + height_half * (prj.y / prj.w),
@@ -361,10 +361,10 @@ def location_3d_to_region_2d( coord ) :
     else:
         return None
 
-def TransformBMVerts( obj , verts ) : 
+def TransformBMVerts( obj , verts ) :
     Item = collections.namedtuple('Item', ('vert', 'region' , 'world' ))
     region = bpy.context.region
-    rv3d = bpy.context.region_data    
+    rv3d = bpy.context.region_data
 
     halfW = region.width / 2.0
     halfH = region.height / 2.0
@@ -372,7 +372,7 @@ def TransformBMVerts( obj , verts ) :
     perspective_matrix = rv3d.perspective_matrix
 
     def Proj2( vt ) :
-        w = matrix_world @ vt.co 
+        w = matrix_world @ vt.co
         v = perspective_matrix @ Vector((w[0], w[1], w[2], 1.0))
         t = None if v.w < 0 else Vector( (halfW+halfW*(v.x/v.w) , halfH+halfH*(v.y/v.w) , ))
         return Item( vert = vt , region = t , world = w )
@@ -411,7 +411,7 @@ def MovePointFromRegion( obj , element , orig , pos ):
             vert.co = obj.matrix_world.inverted() @ v
 
     return orig + p
-    
+
 def MakePointFromRegion( obj , bm , pos , pivot : Vector ):
     p = CalcPositionFromRegion( pos , pivot )
     p = obj.matrix_world.inverted() @ p
@@ -422,7 +422,7 @@ def MakePointFromRegion( obj , bm , pos , pivot : Vector ):
 
 
 def CalcRateEdgeRay( obj , context , edge , vert , coord , ray , dist ) :
-    matrix = obj.matrix_world        
+    matrix = obj.matrix_world
     v0 = vert.co
     v1 = edge.other_vert(vert).co
     p0 = location_3d_to_region_2d( matrix @ v0)
@@ -442,4 +442,4 @@ def CalcRateEdgeRay( obj , context , edge , vert , coord , ray , dist ) :
     elif d1 > dt :
         return 0.0
     else :
-        return max( 0 , min( 1 , d0 / dt ))        
+        return max( 0 , min( 1 , d0 / dt ))


### PR DESCRIPTION
Blender3.0にて、Shift押しのサイクル選択での、メッシュのリラックス・一括移動・一括削除が失敗する問題を修正しました。 (Blender3.0の仕様変更が原因)